### PR TITLE
ortp >= 0.24.1 is the minimum requirement

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -811,7 +811,7 @@ if test "$ortp_enabled" = 'true'; then
 		fi
 	fi
 	if test "$external_ortp" = 'true'; then
-		PKG_CHECK_MODULES(ORTP, ortp >= 0.24.0, ,
+		PKG_CHECK_MODULES(ORTP, ortp >= 0.24.1, ,
 			[ AC_MSG_ERROR([Couldn't find ortp library]) ] )
 	fi
 else


### PR DESCRIPTION
rtp_session_get_symmetric_rtp() was introduced by 3585f885 .
This commit is included in version 0.24.1 .