### PR TITLE
pulseaudio.c: fix output stuttering due to underflows

### DIFF
--- a/src/audiofilters/pulseaudio.c
+++ b/src/audiofilters/pulseaudio.c
@@ -349,11 +349,17 @@ static void stream_free(Stream *s) {
 }
 
 static size_t stream_play(Stream *s, size_t nbytes) {
-	if (nbytes == 0) return 0;
+	size_t avail;
 
-	if (ms_bufferizer_get_avail(&s->bufferizer) >= nbytes){
+	if (nbytes == 0)
+		return 0;
+
+	avail = ms_bufferizer_get_avail(&s->bufferizer);
+	if (avail > 0) {
 		uint8_t *data;
 		int buffer_size;
+		if (nbytes > avail)
+			nbytes = avail;
 		data = ms_new(uint8_t, nbytes);
 		ms_mutex_lock(&s->mutex);
 		ms_bufferizer_read(&s->bufferizer, data, nbytes);


### PR DESCRIPTION
Pulseaudio write filter is writing data only when available data is more than available space in pulseaudio's pipeline.
When data is coming at a slow pace, there can be a race in which pulseaudio available space is increasing faster than available data. This leads to underruns and stuttering sound.

This patch allows pulseaudio filter to write data as soon as it is available, up to filling available space in pulseaudio's pipeline.
