### PR TITLE
Actually enable the auto focus for video call in Android

### DIFF
--- a/java/src/org/linphone/mediastream/video/capture/AndroidVideoApi9JniWrapper.java
+++ b/java/src/org/linphone/mediastream/video/capture/AndroidVideoApi9JniWrapper.java
@@ -60,6 +60,11 @@ public class AndroidVideoApi9JniWrapper {
 		params.setPreviewSize(width, height); 
 		int[] chosenFps = findClosestEnclosingFpsRange(fps*1000, params.getSupportedPreviewFpsRange());
 		params.setPreviewFpsRange(chosenFps[0], chosenFps[1]);
+
+		if(camera.getParameters().getSupportedFocusModes().contains(Parameters.FOCUS_MODE_CONTINUOUS_VIDEO)) {
+            params.setFocusMode(Parameters.FOCUS_MODE_CONTINUOUS_VIDEO);
+        }
+
 		camera.setParameters(params);
 
 		int bufferSize = (width * height * ImageFormat.getBitsPerPixel(params.getPreviewFormat())) / 8;


### PR DESCRIPTION
Although there is `activateAutoFocus` function in `AndroidVideoApi5JniWrapper.java`, it is never used. More importantly calling `camera.autoFocus(null)` in `activateAutoFocus` actually will only trigger the camera to focus once.

In order to make the camera continuously auto focus during a video call, need to explicitly set the parameter.