### PR TITLE
fix bug: msiounit.m will cause CFRunLoopTimerRef memory leak.

### DIFF
--- a/src/audiofilters/msiounit.m
+++ b/src/audiofilters/msiounit.m
@@ -872,6 +872,8 @@ static void au_read_uninit(MSFilter *f) {
 	check_unused(card);
 
 	ms_mutex_destroy(&d->mutex);
+
+	flushq(&d->rq,0);
 	ms_free(d);
 }
 

--- a/src/audiofilters/msiounit.m
+++ b/src/audiofilters/msiounit.m
@@ -557,6 +557,7 @@ static void cancel_audio_unit_timer(au_card_t* card){
 	if (card->shutdown_timer){
 		CFRunLoopRemoveTimer(CFRunLoopGetMain(), card->shutdown_timer,kCFRunLoopCommonModes);
 		CFRunLoopTimerInvalidate(card->shutdown_timer);
+        CFRelease(card->shutdown_timer);
 		card->shutdown_timer=NULL;
 	}
 }


### PR DESCRIPTION
Hi, I found card->shutdown_timer object doesn't release in msiounit.m