### PR TITLE
Fix bug in checking ICE candidate counts

### DIFF
--- a/src/voip/ice.c
+++ b/src/voip/ice.c
@@ -2789,7 +2789,7 @@ IceCandidate * ice_add_remote_candidate(IceCheckList *cl, const char *type, int 
 	bctbx_list_t *elem;
 	IceCandidate *candidate;
 
-	if (bctbx_list_size(cl->local_candidates) >= ICE_MAX_NB_CANDIDATES) {
+	if (bctbx_list_size(cl->remote_candidates) >= ICE_MAX_NB_CANDIDATES) {
 		ms_error("ice: Candidate list limited to %d candidates", ICE_MAX_NB_CANDIDATES);
 		return NULL;
 	}


### PR DESCRIPTION
The length check for `ice_add_remote_candidate` should check the correct list.