### PR TITLE
Fix encoding of STUN ERROR-CODE attribute.

### DIFF
--- a/src/voip/stun.c
+++ b/src/voip/stun.c
@@ -198,8 +198,10 @@ static void encode_string(StunMessageEncoder *encoder, uint16_t type, const char
 
 static void encode_error_code(StunMessageEncoder *encoder, uint16_t number, const char *reason) {
 	size_t reason_len = 0;
-	size_t padding = 4 - (reason_len % 4);
+	size_t padding;
+
 	if (reason != NULL) reason_len = strlen(reason);
+	padding = 4 - (reason_len % 4);
 	encode16(encoder, MS_STUN_ATTR_ERROR_CODE);
 	encode16(encoder, 4 + (uint16_t)reason_len);
 	encode16(encoder, 0);


### PR DESCRIPTION
When encode_error_code is invoked with a reason, for example
"Role Conflict", the reason ERROR-CODE attribute is encoded
with incorrect padding (always 0 bytes of padding).

The reason is that the padding calculation is done before the strlen()
call to determine the reason length.

This was discovered while investigating a FreeSwitch crash:

https://freeswitch.org/jira/browse/FS-10394