### PR TITLE
Update list of HD incapable devices

### DIFF
--- a/src/voip/ioshardware.m
+++ b/src/voip/ioshardware.m
@@ -38,9 +38,9 @@
 
 // see http://theiphonewiki.com/wiki/Models , these come from our experience
 NSString* notHDCapableFamilies[] = {
-	@"iPod1", @"iPod2", @"iPod3", @"iPod4",
-	@"iPhone1", @"iPhone2", @"iPhone3", @"iPhone4",
-	@"iPad1", @"iPad2" };
+	@"iPod1,", @"iPod2,", @"iPod3,", @"iPod4,",
+	@"iPhone1,", @"iPhone2,", @"iPhone3,", @"iPhone4,",
+	@"iPad1,", @"iPad2," };
 
 + (BOOL) isHDVideoCapableDevice:(NSString*)device {
 	for (int i = 0; i<sizeof(notHDCapableFamilies)/sizeof(NSString*); i++) {


### PR DESCRIPTION
The list of HD incapable devices will incorrectly match newer iOS devices such as iPhoneX and iPhone8. This is due to the fact that iPhoneX is reported as "iPhone10,3" and "iPhone10,6" which will match "iPhone1" in the hasPrefix check. Added a comma to each of the devices in the list to prevent them from matching.