### PR TITLE
m4: add -ldrm when checking for avcodec functions

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -110,7 +110,7 @@ AC_DEFUN([MS_CHECK_VIDEO],[
 			if test x$avcodec_found = xno ; then
 			   AC_MSG_WARN([Could not find libavcodec (from ffmpeg) headers and library.])
 			else
-			   FFMPEG_LIBS="$FFMPEG_LIBS -lavutil"
+			   FFMPEG_LIBS="$FFMPEG_LIBS -lavutil -ldrm"
 			fi
 			
 			


### PR DESCRIPTION
Autotools miss avcodec function check.
This is due to linker library list order, -ldrm is appended too early
respect to -lavcodec. This results in missing drm library functions for
avcodec functions:
- drmGetVersion()
- drmFreeVersion()
So these functions:
- avcodec_get_context_defaults3
- avcodec_open2
- avcodec_encode_video2
can't link correctly during check and they seem not to be present.
Then macros HAVE_FUN_avcodec_* are not defined in mediastreamer-config.h
So local avcodec functions conflict with real avcodec library functions.

In acinclude.m4 file, append -ldrm to FFMPEG_LIBS if avcodec is found.

Signed-off-by: Giulio Benetti <giulio.benetti@micronovasrl.com>