### PR TITLE
Use AV_INPUT_BUFFER_PADDING_SIZE to determine padding size

### DIFF
--- a/src/utils/ffmpeg-priv.h
+++ b/src/utils/ffmpeg-priv.h
@@ -115,6 +115,10 @@ static inline int avcodec_decode_video2(AVCodecContext *avctx, AVFrame *picture,
 extern "C" {
 #endif
 
+#ifndef AV_INPUT_BUFFER_PADDING_SIZE
+    #define AV_INPUT_BUFFER_PADDING_SIZE FF_INPUT_BUFFER_PADDING_SIZE
+#endif
+
 #ifndef HAVE_FUN_avcodec_encode_video2
 int avcodec_encode_video2 (AVCodecContext *avctx, AVPacket *avpkt, const AVFrame *frame, int *got_packet_ptr);
 #endif

--- a/src/videofilters/ffmpegnowebcam.c
+++ b/src/videofilters/ffmpegnowebcam.c
@@ -31,7 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #ifndef NO_FFMPEG
 #include "ffmpeg-priv.h"
 #else
-#define FF_INPUT_BUFFER_PADDING_SIZE 32
+#define AV_INPUT_BUFFER_PADDING_SIZE 32
 #endif
 
 #if LIBAVCODEC_VERSION_MAJOR >= 57

--- a/src/videofilters/nowebcam.c
+++ b/src/videofilters/nowebcam.c
@@ -34,7 +34,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-#define FF_INPUT_BUFFER_PADDING_SIZE 32
+#ifndef NO_FFMPEG
+#include "ffmpeg-priv.h"
+#else
+#define AV_INPUT_BUFFER_PADDING_SIZE 32
+#endif
 
 #if LIBAVCODEC_VERSION_MAJOR >= 57
 
@@ -130,7 +134,7 @@ static mblk_t *_ms_load_jpeg_as_yuv(const char *jpgpath, MSVideoSize *reqsize) {
 			ms_error("Cannot load %s", jpgpath);
 			return NULL;
 		}
-		jpgbuf=(uint8_t*)ms_malloc0(statbuf.st_size + FF_INPUT_BUFFER_PADDING_SIZE);
+		jpgbuf=(uint8_t*)ms_malloc0(statbuf.st_size + AV_INPUT_BUFFER_PADDING_SIZE);
 		if (jpgbuf == NULL) {
 			close(fd);
 			ms_error("Cannot allocate buffer for %s", jpgpath);


### PR DESCRIPTION
Hardcoding the value for FF_INPUT_BUFFER_PADDING_SIZE is not safe because
upstream FFmpeg might change it (as they did in FFmpeg 4.0).

Instead, use FFmpeg's AV_INPUT_BUFFER_PADDING_SIZE if available and only
hardcode a value if FFmpeg is disabled (in which case the value doesn't
particularly matter anyway). For compatibility with older FFmpeg versions,
define AV_INPUT_BUFFER_PADDING_SIZE if hasn't been defined yet.

Source: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=901735