### PR TITLE
Fix WAV audio recordings

### DIFF
--- a/src/audiofilters/msfilerec.c
+++ b/src/audiofilters/msfilerec.c
@@ -151,6 +151,10 @@ static int rec_open(MSFilter *f, void *arg){
 				ms_error("Could not lseek to end of file: %s",strerror(err));
 			}
 		}else ms_error("fstat() failed: %s",strerror(errno));
+	}else{
+                if (s->is_wav){
+                        write_wav_header(s->fd, s->rate, s->nchannels, s->size);
+                }
 	}
 	ms_message("MSFileRec: recording into %s",filename);
 	s->writer = ms_async_writer_new(s->fd);


### PR DESCRIPTION
Using WAV as the audio recording format resulted in corrupted files where the chunk length did not properly correspond to the actual chunk content or file length.

This was caused by initially writing the audio samples to the start of the file instead of the data chunk. On close, writing the WAV header would then overwrite the first bytes of audio.