### PR TITLE
did set h264dec (which uses ffmpeg) as decoder

### DIFF
--- a/include/mediastreamer2/msqueue.h
+++ b/include/mediastreamer2/msqueue.h
@@ -71,6 +71,9 @@ static MS2_INLINE bool_t ms_queue_end(const MSQueue *q, const mblk_t *m){
 }
 
 static MS2_INLINE mblk_t *ms_queue_peek_next(MSQueue *q, mblk_t *cur){
+	if (q)
+		return cur->b_next;
+
 	return cur->b_next;
 }
 

--- a/src/videofilters/h264dec.cpp
+++ b/src/videofilters/h264dec.cpp
@@ -84,6 +84,7 @@ static void dec_open(DecData *d){
 }
 
 static void dec_init(MSFilter *f){
+	ms_message("ffmpeg's h264 decoder");
 	DecData *d=ms_new0(DecData,1);
 	ffmpeg_init();
 	d->sps=NULL;

--- a/src/voip/h26x/videotoolbox.cpp
+++ b/src/voip/h26x/videotoolbox.cpp
@@ -96,7 +96,7 @@ extern "C" void _register_videotoolbox_if_supported(MSFactory *factory) {
 		if (codecInfo->encoderIsAvailable()) {
 			ms_message("Registering VideoToolbox H264 codec");
 			ms_factory_register_filter(factory, &ms_VideoToolboxH264Encoder_desc);
-			ms_factory_register_filter(factory, &ms_VideoToolboxH264Decoder_desc);
+			// ms_factory_register_filter(factory, &ms_VideoToolboxH264Decoder_desc);
 		} else {
 			ms_message("No H264 encoder found on this device");
 		}

--- a/src/voip/msvoip.c
+++ b/src/voip/msvoip.c
@@ -272,13 +272,13 @@ void ms_factory_init_voip(MSFactory *obj){
 #endif
 
 #if defined(__APPLE__) && defined(VIDEO_ENABLED)
-	_register_videotoolbox_if_supported(obj);
+       _register_videotoolbox_if_supported(obj);
 #endif
 
 #if defined(__ANDROID__) && defined(VIDEO_ENABLED)
 	if (AMediaImage_isAvailable()) {
 		if (AMediaCodec_checkCodecAvailability("video/avc")) {
-			ms_factory_register_filter(obj, &ms_MediaCodecH264Decoder_desc);
+		// 	ms_factory_register_filter(obj, &ms_MediaCodecH264Decoder_desc);
 			ms_factory_register_filter(obj, &ms_MediaCodecH264Encoder_desc);
 		}
 		if (AMediaCodec_checkCodecAvailability("video/hevc")) {


### PR DESCRIPTION
Hi,
with this PR (initially developed by Media Magic Technologies, updated by Divus GmbH) and the PR for **linphone-cmake-builder** we have updated the version of **ffmpeg**, so that newer versions of the codecs can be used, improving the functionality especially on Android systems.

You also need to update the pointed **ffmpeg** submodule, so that it includes the release 4.4.2